### PR TITLE
Asynchronous mode for Space record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .hgignore
 .hg/
 .cljs_rhino_repl/
+/.idea
+*.iml

--- a/config/test_async.clj
+++ b/config/test_async.clj
@@ -1,0 +1,9 @@
+{:tarantool {:host "localhost"
+             :port 3301
+             :username "tester"
+             :password "tester"
+             :async? true}
+ :tester-tuple-space 1
+ :tester-space {:name "tester"
+                :fields [:id :first-name :second-name]
+                :tail :_tail}}

--- a/src/tarantool_clj/connection.clj
+++ b/src/tarantool_clj/connection.clj
@@ -37,6 +37,12 @@
     (throw data)
     data))
 
+(defn- safe-callback
+  [data callback-fn]
+  (if (= java.lang.Exception (type data))
+    data
+    (callback-fn data)))
+
 (defn- get-response
   [input]
   (let [[length header body] (repeatedly 3 #(get-msgpack-packet input))]
@@ -250,7 +256,7 @@
                                      response-chan (:chan (get requests response-id))
                                      callback-fn (:callback-fn (get requests response-id))]
                                  (if response-chan
-                                   (a/>!! response-chan (callback-fn data))
+                                   (a/>!! response-chan (safe-callback data callback-fn))
                                    (log/debug (format "Deadend response %s %s" response-id data)))
                                  (when (or running? (seq requests))
                                    (recur (dissoc requests response-id) running? request-id)))))))))

--- a/src/tarantool_clj/tuple_space.clj
+++ b/src/tarantool_clj/tuple_space.clj
@@ -8,34 +8,45 @@
 (defprotocol TupleSpaceProtocol
   (select
     [this index-id key-tuple]
-    [this index-id key-tuple opts])
-  (insert [this data-tuple])
-  (replace [this data-tuple])
+    [this index-id key-tuple opts]
+    [this index-id key-tuple opts callback-fn])
+  (insert
+    [this data-tuple]
+    [this data-tuple callback-fn])
+  (replace
+    [this data-tuple]
+    [this data-tuple callback-fn])
   (update
     [this key-tuple ops-tuples]
-    [this index-id key-tuple ops-tuples])
+    [this index-id key-tuple ops-tuples]
+    [this index-id key-tuple ops-tuples callback-fn])
   (delete
     [this key-tuple]
-    [this index-id key-tuple])
-  (upsert [this data-tuple ops-tuples])
+    [this index-id key-tuple]
+    [this index-id key-tuple callback-fn])
+  (upsert
+    [this data-tuple ops-tuples])
   (call
     [this function-name]
-    [this function-name args])
+    [this function-name args]
+    [this function-name args callback-fn])
   (eval
     [this expression]
-    [this expression args]))
+    [this expression args]
+    [this expression args callback-fn]))
 
 (defn- select*
   [{:keys [client id] :as tuple-space}
    index-id
    tuple
-   {:keys [limit offset iterator] :or {limit Integer/MAX_VALUE offset 0 iterator :eq}}]
+   {:keys [limit offset iterator] :or {limit Integer/MAX_VALUE offset 0 iterator :eq}}
+   callback-fn]
   (let [iterator-id (get constants/ITERATORS iterator)]
     (when-not iterator-id
       (throw (Exception.
               (format "Wrong iterator %s, not one of %s"
                       iterator (keys constants/ITERATORS)))))
-    (client/select client id index-id limit offset iterator-id tuple)))
+    (client/select client id index-id limit offset iterator-id tuple callback-fn)))
 
 (defrecord TupleSpace [id client]
   component/Lifecycle
@@ -45,28 +56,42 @@
   (select [this index-id key-tuple]
     (select this index-id key-tuple {}))
   (select [this index-id key-tuple opts]
-    (select* this index-id key-tuple opts))
+    (select* this index-id key-tuple opts (fn [v] v)))
+  (select [this index-id key-tuple opts callback-fn]
+    (select* this index-id key-tuple opts callback-fn))
   (insert [{:keys [client]} data-tuple]
     (client/insert client id data-tuple))
+  (insert [{:keys [client]} data-tuple callback-fn]
+    (client/insert client id data-tuple callback-fn))
   (replace [{:keys [client]} data-tuple]
     (client/replace client id data-tuple))
+  (replace [{:keys [client]} data-tuple callback-fn]
+    (client/replace* client id data-tuple callback-fn))
   (update [this key-tuple ops-tuples]
     (update this 0 key-tuple ops-tuples))
   (update [{:keys [client]} index-id key-tuple ops-tuples]
     (client/update client id index-id key-tuple ops-tuples))
+  (update [{:keys [client]} index-id key-tuple ops-tuples callback-fn]
+    (client/update client id index-id key-tuple ops-tuples callback-fn))
   (delete [this key-tuple]
     (delete this 0 key-tuple))
   (delete [{:keys [client]} index-id key-tuple]
     (client/delete client id index-id key-tuple))
+  (delete [{:keys [client]} index-id key-tuple callback-fn]
+    (client/delete client id index-id key-tuple callback-fn))
   (upsert [{:keys [client]} data-tuple ops-tuples])
   (call [this function-name]
     (call this function-name []))
   (call [{:keys [client]} function-name args]
     (client/call client function-name args))
+  (call [{:keys [client]} function-name args callback-fn]
+    (client/call client function-name args callback-fn))
   (eval [this expression]
     (eval this expression []))
   (eval [{:keys [client]} expression args]
-    (client/eval client expression args)))
+    (client/eval client expression args))
+  (eval [{:keys [client]} expression args callback-fn]
+    (client/eval client expression args callback-fn)))
 
 
 (defn new-spaces-tuple-space

--- a/test/tarantool_clj/client_async_test.clj
+++ b/test/tarantool_clj/client_async_test.clj
@@ -1,0 +1,140 @@
+(ns tarantool-clj.client-async-test
+  (:require [tarantool-clj
+             [client :as client]
+             [tuple-space :as tuple-space]
+             [space :as space]
+             [test-utils :refer [with-truncated-tarantool-async]]]
+            [clojure.test :refer :all]
+            [com.stuartsierra.component :as component]
+            [clojure.core.async :as a])
+  (:refer-clojure :exclude [eval update replace]))
+
+(def config (clojure.edn/read-string (slurp "config/test_async.clj")))
+
+(defn client []
+  (-> config
+      :tarantool
+      (client/new-client)
+      (component/start)))
+
+(use-fixtures :each (partial with-truncated-tarantool-async client))
+
+(deftest tuple-space
+  (let [space (->> config
+                   :tester-tuple-space
+                   (tuple-space/new-tuple-space (client))
+                   (component/start))]
+    (are [x y] (= x y)
+               (a/<!! (tuple-space/insert space [1 "Steve" "Buscemi"]))
+               [[1 "Steve" "Buscemi"]]
+
+               (a/<!! (tuple-space/insert space [2 "Steve" "Jobs"]))
+               [[2 "Steve" "Jobs"]]
+
+               (a/<!! (tuple-space/insert space [3 "Tim" "Roth"]))
+               [[3 "Tim" "Roth"]]
+
+               (a/<!! (tuple-space/select space 0 [1]))
+               [[1 "Steve" "Buscemi"]]
+
+               (a/<!! (tuple-space/select space 1 ["Steve"] {:iterator :eq}))
+               [[1 "Steve" "Buscemi"] [2 "Steve" "Jobs"]]
+
+               (a/<!! (tuple-space/delete space [1]))
+               [[1 "Steve" "Buscemi"]]
+
+               (a/<!! (tuple-space/select space 1 ["Steve"] {:iterator :eq}))
+               [[2 "Steve" "Jobs"]]
+
+               (a/<!! (tuple-space/update space [2] [["=" 2 "Ballmer"]]))
+               [[2 "Steve" "Ballmer"]]
+
+               (a/<!! (tuple-space/select space 1 ["Steve"]))
+               [[2 "Steve" "Ballmer"]])))
+
+
+
+(deftest space
+  (let [space (->> config
+                   :tester-space
+                   (space/new-space (client))
+                   (component/start))]
+    (are [x y] (= x y)
+               (a/<!! (space/insert space
+                             {:id 1
+                              :first-name "Steve"
+                              :second-name "Buscemi"}))
+               '({:id 1 :first-name "Steve" :second-name "Buscemi"})
+
+               (a/<!! (space/insert space
+                             {:id 2
+                              :first-name "Steve"
+                              :second-name "Jobs"}))
+               '({:id 2 :first-name "Steve" :second-name "Jobs"})
+
+               (a/<!! (space/insert space
+                             {:id 3
+                              :first-name "Tim"
+                              :second-name "Roth"}))
+               '({:id 3 :first-name "Tim" :second-name "Roth"})
+
+               (a/<!! (space/insert space
+                             {:id 4
+                              :first-name "Bill"
+                              :second-name "Gates"
+                              :_tail [1 2 3 4 5]}))
+               '({:id 4 :first-name "Bill" :second-name "Gates" :_tail (1 2 3 4 5)})
+
+               (a/<!! (space/select-first space
+                                   {:id 1}))
+               {:id 1 :first-name "Steve" :second-name "Buscemi"}
+
+               (a/<!! (space/select space
+                             {:first-name "Steve"}))
+               '({:id 1 :first-name "Steve" :second-name "Buscemi"}
+                  {:id 2 :first-name "Steve" :second-name "Jobs"})
+
+               (a/<!! (space/select space
+                             {:first-name "Steve" :second-name "Jobs"}))
+               '({:id 2 :first-name "Steve" :second-name "Jobs"})
+
+               (a/<!! (space/select space
+                             {:first-name "Steve"}
+                             {:iterator :eq}))
+               '({:id 1 :first-name "Steve" :second-name "Buscemi"}
+                  {:id 2 :first-name "Steve" :second-name "Jobs"})
+
+               (a/<!! (space/select space
+                             {:first-name "Steve"}
+                             {:iterator :eq :offset 1 :limit 100}))
+               '({:id 2 :first-name "Steve" :second-name "Jobs"})
+
+               (a/<!! (space/update space
+                             {:id 2}
+                             {:second-name ["=" "Ballmer"]}))
+               '({:id 2 :first-name "Steve" :second-name "Ballmer"})
+
+               (a/<!! (space/update space
+                             {:id 2}
+                             {:second-name [":" 3 4 "dwin"]
+                              :first-name [":" 3 4 "phen"]}))
+               '({:id 2 :first-name "Stephen" :second-name "Baldwin"})
+
+               (a/<!! (space/delete space
+                             {:id 3}))
+               '({:id 3 :first-name "Tim" :second-name "Roth"})
+
+               (a/<!! (space/replace space
+                              {:id 4 :first-name "Bill" :second-name "Murray"}))
+               '({:id 4 :first-name "Bill" :second-name "Murray"})
+
+               (a/<!! (space/eval space
+                           "function ping()
+                                 return 'pong'
+                               end"))
+               []
+
+               (a/<!! (space/call space
+                           "ping"))
+               ["pong"])))
+

--- a/test/tarantool_clj/client_async_test.clj
+++ b/test/tarantool_clj/client_async_test.clj
@@ -35,8 +35,11 @@
                [[3 "Tim" "Roth"]]
 
                (a/<!! (tuple-space/select space 0 [1]))
-               [[1 "Steve" "Buscemi"]]
+               [[1 "Steve" "Buscemi"]])
 
+    (is (= (type (a/<!!(tuple-space/insert space [3 "Tim" "Roth"]))) java.lang.Exception))
+
+    (are [x y] (= x y)
                (a/<!! (tuple-space/select space 1 ["Steve"] {:iterator :eq}))
                [[1 "Steve" "Buscemi"] [2 "Steve" "Jobs"]]
 
@@ -76,8 +79,12 @@
                              {:id 3
                               :first-name "Tim"
                               :second-name "Roth"}))
-               '({:id 3 :first-name "Tim" :second-name "Roth"})
+               '({:id 3 :first-name "Tim" :second-name "Roth"}))
 
+    (is (= (type (a/<!!(space/insert space {:id 3
+                                            :first-name "Tim"
+                                            :second-name "Roth"}))) java.lang.Exception))
+    (are [x y] (= x y)
                (a/<!! (space/insert space
                              {:id 4
                               :first-name "Bill"
@@ -137,4 +144,3 @@
                (a/<!! (space/call space
                            "ping"))
                ["pong"])))
-

--- a/test/tarantool_clj/client_test.clj
+++ b/test/tarantool_clj/client_test.clj
@@ -33,7 +33,11 @@
       [[3 "Tim" "Roth"]]
 
       (tuple-space/select space 0 [1])
-      [[1 "Steve" "Buscemi"]]
+      [[1 "Steve" "Buscemi"]])
+
+    (is (thrown? Exception (tuple-space/insert space [3 "Tim" "Roth"])))
+
+    (are [x y] (= x y)
 
       (tuple-space/select space 1 ["Steve"] {:iterator :eq})
       [[1 "Steve" "Buscemi"] [2 "Steve" "Jobs"]]
@@ -79,7 +83,14 @@
                      :first-name "Bill"
                      :second-name "Gates"
                      :_tail [1 2 3 4 5]})
-      '({:id 4 :first-name "Bill" :second-name "Gates" :_tail (1 2 3 4 5)})
+      '({:id 4 :first-name "Bill" :second-name "Gates" :_tail (1 2 3 4 5)}))
+
+    (is (thrown? Exception (space/insert space {:id 4
+                                                :first-name "Bill"
+                                                :second-name "Gates"
+                                                :_tail [1 2 3 4 5]})))
+
+    (are [x y] (= x y)
 
       (space/select-first space
                           {:id 1})

--- a/test/tarantool_clj/test_utils.clj
+++ b/test/tarantool_clj/test_utils.clj
@@ -1,6 +1,7 @@
 (ns tarantool-clj.test-utils
   (:require [com.stuartsierra.component :as component]
-            [tarantool-clj.client :as client]))
+            [tarantool-clj.client :as client]
+            [clojure.core.async :as a]))
 
 (defn with-truncated-tarantool
   [client f]
@@ -11,3 +12,14 @@
       (f)
       (finally
         (client/call client "drop_testing_space" [])))))
+
+(defn with-truncated-tarantool-async
+  "Для асихрона нужна отдельная функция: чтобы дождаться создания спейса перед началом теста"
+  [client f]
+  (let [client (client)]
+    (a/<!! (client/eval client (slurp (clojure.java.io/resource "scripts/app.lua")) []))
+    (a/<!! (client/call client "create_testing_space" []))
+    (try
+      (f)
+      (finally
+        (a/<!! (client/call client "drop_testing_space" []))))))


### PR DESCRIPTION
Reproducer:
Lets add test for space and tuple-space with asynchronous mode.
New config:
https://github.com/Sberbank-Technology/tarantool-clj-1.7/blob/master/config/test_async.clj
New test file:
https://github.com/Sberbank-Technology/tarantool-clj-1.7/blob/master/test/tarantool_clj/client_async_test.clj
Test results:
tuple-space test - {:test 1, :pass 9, :fail 0, :error 0, :type :summary}
space test - {:test 1, :pass 0, :fail 0, :error 15, :type :summary}
When i tried "(space/select-first space {:id 1})", i got "CompilerException java.lang.IllegalArgumentException: Don't know how to create ISeq from: clojure.core.async.impl.channels.ManyToManyChannel, compiling:(D:/work/connector/test/tarantool_clj/client_async_test.clj:26:1)". It happened cause record TarantoolConnection returned channel (in async mode), then record Space tried to exec function first with channel. Same with other funcs.
My offer: add parameter callback-function to send-request at Connection. This callback-fn contains function for processing data from tarantool, so data in channel is ready for use and there is no need to process data in Space record.
Lets discuss this solution.